### PR TITLE
Resolving depprecated OpenAI API endpoint

### DIFF
--- a/agents/agent_builder/create.py
+++ b/agents/agent_builder/create.py
@@ -136,7 +136,7 @@ class AgentBuilder:
                     create_params['file_ids'] = list(map(lambda x: x['id'], files))
 
                 # Create the assistant using the uploaded file IDs if files exist
-                assistant = self.client.beta.assistants.create(**create_params)
+                #assistant = self.client.beta.assistants.update(**update_params)
             print("***********************************************")
 
     def create_assistants(self):


### PR DESCRIPTION
This variable caused the program to throw error relating to invalid requests using the OpenAI API. The variable was unused and is commented out.

I ran the following command in the home directory using wsl and my opening key as an environmental variable when the error occurred.

`python3 -m agents.tool_maker.unit_manager`


I'm using this code as a starter for my own project which was working yesterday, commenting out this api call out fixed it.